### PR TITLE
Support for username

### DIFF
--- a/QuserObject/Private/Invoke-Quser.ps1
+++ b/QuserObject/Private/Invoke-Quser.ps1
@@ -6,6 +6,10 @@
     .Parameter Server
 
         A server to target. No validation or reachability testing is done.
+
+    .Parameter UserOrSession
+
+        Optional username, sessionname or sessionid to pass on to QUser.exe.
 #>
 function Invoke-Quser {
     [CmdletBinding()]
@@ -13,7 +17,10 @@ function Invoke-Quser {
     Param(
         [Parameter(ValueFromPipeline)]
         [string]
-        $Server
+        $Server,
+
+        [string]
+        $UserOrSession = ''
     )
 
     begin {
@@ -26,12 +33,14 @@ function Invoke-Quser {
         Write-Debug "[QuserObject Invoke-Quser] Process Unbound Parameters: $($MyInvocation.UnboundParameters | ConvertTo-Json)"
 
         if ($Server -eq 'localhost') {
-            $cmd = '{0}'
+            $cmd = '{0}{1}'
         } else {
-            $cmd = '{0} /SERVER:{1}'
+            $cmd = '{0}{1} /SERVER:{2}'
         }
-        
-        $quser = $cmd -f (Get-Command 'quser').Path, $Server
+
+        # crude conditional add of sapce
+        if ($UserOrSession) { $UserOrSession = ' ' + $UserOrSession }
+        $quser = $cmd -f (Get-Command 'quser').Path, $UserOrSession, $Server
         Write-Debug "[QuserObject Invoke-Quser] QUSER Command: ${quser}"
 
         try {

--- a/QuserObject/Private/Invoke-Quser.ps1
+++ b/QuserObject/Private/Invoke-Quser.ps1
@@ -35,7 +35,7 @@ function Invoke-Quser {
         if ($Server -eq 'localhost') {
             $cmd = '{0}{1}'
         } else {
-            $cmd = '{0}{1} /SERVER:{2}'
+            $cmd = '{0} {1} /SERVER:{2}'
         }
 
         $quser = $cmd -f (Get-Command 'quser').Path, $UserOrSession, $Server

--- a/QuserObject/Private/Invoke-Quser.ps1
+++ b/QuserObject/Private/Invoke-Quser.ps1
@@ -38,8 +38,6 @@ function Invoke-Quser {
             $cmd = '{0}{1} /SERVER:{2}'
         }
 
-        # crude conditional add of sapce
-        if ($UserOrSession) { $UserOrSession = ' ' + $UserOrSession }
         $quser = $cmd -f (Get-Command 'quser').Path, $UserOrSession, $Server
         Write-Debug "[QuserObject Invoke-Quser] QUSER Command: ${quser}"
 

--- a/QuserObject/Private/Invoke-Quser.ps1
+++ b/QuserObject/Private/Invoke-Quser.ps1
@@ -9,7 +9,7 @@
 
     .Parameter UserOrSession
 
-        Optional username, sessionname or sessionid to pass on to QUser.exe.
+        Optional username, sessionname, or sessionid to pass on to `quser.exe`.
 #>
 function Invoke-Quser {
     [CmdletBinding()]

--- a/QuserObject/Public/Get-Quser.ps1
+++ b/QuserObject/Public/Get-Quser.ps1
@@ -13,6 +13,10 @@
 
         Setting this switch will return IdleTime as [datetime] of when idleness started.
 
+    .Parameter UserOrSession
+
+        Optional username, sessionname or sessionid to pass on to QUser.exe.
+
     .Parameter AdComputer
 
         The AD computer object of the server to be queried.
@@ -30,6 +34,10 @@
     .Example
 
         Get-Quser -Server 'ThisServer'
+
+    .Example
+
+        Get-Quser -Server 'ThisServer' -UserOrSession 'Administrator'
 
     .Example
 
@@ -59,6 +67,10 @@ function Get-Quser {
         [switch]
         $IdleStartTime,
 
+        [Alias('UserName', 'SessionName', 'SessionId')]
+        [string]
+        $UserOrSession = '',
+
         [Parameter(
             ParameterSetName = 'AdComputer',
             ValueFromPipeline = $true,
@@ -86,9 +98,9 @@ function Get-Quser {
         Write-Debug "[QuserObject Get-Quser] Process Unbound Parameters: $($MyInvocation.UnboundParameters | ConvertTo-Json)"
 
         if ($AdComputer) {
-            Write-Output ($AdComputer.$Property | Invoke-Quser | ConvertTo-QuserObject)
+            Write-Output ($AdComputer.$Property | Invoke-Quser -UserOrSession $UserOrSession | ConvertTo-QuserObject)
         } else {
-            Write-Output ($Server | Invoke-Quser | ConvertTo-QuserObject)
+            Write-Output ($Server | Invoke-Quser -UserOrSession $UserOrSession | ConvertTo-QuserObject)
         }
     }
 }

--- a/QuserObject/Public/Get-Quser.ps1
+++ b/QuserObject/Public/Get-Quser.ps1
@@ -15,7 +15,7 @@
 
     .Parameter UserOrSession
 
-        Optional username, sessionname or sessionid to pass on to QUser.exe.
+        Optional username, sessionname, or sessionid to pass on to `quser.exe`.
 
     .Parameter AdComputer
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The return `IdleTime` property will be different depending on whether or not thi
 - Type: `[string]`
 - Default: ``
 
-Optional username, sessionname or sessionid to pass on to QUser.exe.
+Optional username, sessionname, or sessionid to pass on to `quser.exe`.
 
 ## AdComputer
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ The return `IdleTime` property will be different depending on whether or not thi
 - Parameter Not Set: `[System.TimeSpan] '3.04:05:00'`
 - Parameter Is Set: `[System.DateTime] '07/29/2018 07:56:00'`
 
+## UserOrSession
+
+- Type: `[string]`
+- Default: ``
+
+Optional username, sessionname or sessionid to pass on to QUser.exe.
+
 ## AdComputer
 
 - Type: `[PSObject]`


### PR DESCRIPTION
As per issue #8 I have added in the capability to pass through a username (or sessionname or sessionid) to QUser to limit the users it looks at.  This seems to be working fine. I went for option of one new parameter UserOrSession aliased to UserName, SessionName and SessionId.