### PR TITLE
Substring instead of TrimStart to get restOfRow

### DIFF
--- a/QuserObject/Private/ConvertTo-QuserObject.ps1
+++ b/QuserObject/Private/ConvertTo-QuserObject.ps1
@@ -54,7 +54,7 @@ function ConvertTo-QuserObject {
             $rowUserName = $row.Substring($usernameSize[0], $usernameSize[1])
             Write-Debug "[QuserObject ConvertTo-QuserObject] Row UserName: $rowUserName"
             
-            $restOfRow = $row.TrimStart($rowUserName).Trim()
+            $restOfRow = $row.Substring($usernameSize[1]).Trim()
             Write-Debug "[QuserObject ConvertTo-QuserObject] Rest of Row [$($row.GetType())]: ${restOfRow}"
 
             [Collections.ArrayList] $rowSplit = $restOfRow -split '\s{2,}'


### PR DESCRIPTION
Using TrimStart leads to some undesired behaviour, which I have fixed by using Substring instead.

TrimStart trims any and all of the provided characters from the beginning of the string, regardless of order or repetitions.
This caused two different problems I observed:

1) If the `SessionName` began with any of the characters contained in `UserName`, those characters would be trimmed off of the `SessionName`.  Example:
```
Id UserName            LogonTime             State  Server    IsCurrentSession IdleTime SessionName
-- --------            ---------             -----  ------    ---------------- -------- -----------
 4 ian.weir          6/10/2021 5:23:00 PM  Active localhost             True          dp-tcp#79
```
The expected SessionName in this case would be `rdp-tcp#79`, but the `r` was trimmed off because it's contained in the `UserName`.

2) If the `UserName` contained all the digits of the `Id`, the ID was trimmed off entirely resulting in the below error since there were too few parameters.  The effected user wouldn't appear in the output at all.
For example, if the session ID was `22` and the username was `user2`, you'd get this error message:

```
Get-QuserIdleTime : Cannot bind argument to parameter 'QuserIdleTime' because it is an empty string.
At C:\Program Files\WindowsPowerShell\Modules\QuserObject\1.0.48\Private\ConvertTo-QuserObject.ps1:82 char:47
+                 IdleTime = (Get-QuserIdleTime @getQuserIdleTime)
+                                               ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Get-QuserIdleTime], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,Get-QuserIdleTime
```